### PR TITLE
Add measurement count to sensor

### DIFF
--- a/src/archive.js
+++ b/src/archive.js
@@ -103,6 +103,9 @@ async function main() {
                 },
               },
             },
+            count: {
+              $count: {},
+            },
           },
         },
         {
@@ -111,6 +114,7 @@ async function main() {
               avg: "$avg",
               min: "$min",
               max: "$max",
+              count: "$count",
             },
           },
         },
@@ -164,6 +168,7 @@ async function main() {
               sensor["avg"] = stats[0].avg;
               sensor["min"] = stats[0].min;
               sensor["max"] = stats[0].max;
+              sensor["count"] = stats[0].count;
             }
           });
 


### PR DESCRIPTION
Add count attribute for each sensor of a device. ( closes #24 )
You can finde the attribute in the `.json` file of a device.

```json
{
  "name": "...",
  "exposure": "...",
  "sensors": [
    {
      "title": "...",
      "unit": "...",
      "sensorType": "...",
      "icon": "...",
      "_id": "...",
      "lastMeasurement": "...",
      "avg": 25.914965277777778,
      "min": 25.72,
      "max": 26.05,
      "count": 1440
    },
    {
      "title": "...",
      "unit": "...",
      "sensorType": "...",
      "icon": "...",
      "_id": "...",
      "lastMeasurement": "...",
      "avg": 13.376138888888889,
      "min": 12.5,
      "max": 14.44,
      "count": 1440
    },
    ...
}
```